### PR TITLE
Fix mobile responsiveness

### DIFF
--- a/src/components/DevPage.tsx
+++ b/src/components/DevPage.tsx
@@ -2,7 +2,7 @@ import { MainScreenDev } from './homepageDev/MainScreenDev'
 
 export const DevPage = () => {
   return (
-    <div className="min-h-screen w-screen bg-[#171717]">
+    <div className="min-h-screen w-full bg-[#171717]">
       <MainScreenDev />
     </div>
   )

--- a/src/components/homepageDev/CommitGrid.tsx
+++ b/src/components/homepageDev/CommitGrid.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { ContributionData } from './commitTypes'
 import { normalizeCount, getBlackbodyColor, formatDate } from './commitUtils'
 
@@ -41,8 +41,32 @@ const getMonthLabels = (
 
 export const CommitGrid = ({ data }: Props) => {
   const [tooltip, setTooltip] = useState<Tooltip | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [maxWeeks, setMaxWeeks] = useState(52)
 
-  const flatDays = data.weeks.flatMap((w) => w.days)
+  const cellSize = 12
+  const gap = 3
+  const step = cellSize + gap
+  const labelWidth = 32
+
+  // Measure container and compute how many weeks fit
+  useEffect(() => {
+    const measure = () => {
+      const container = containerRef.current
+      if (!container) return
+      const available = container.clientWidth - labelWidth - 8
+      const weeksThatFit = Math.max(4, Math.floor(available / step))
+      setMaxWeeks(Math.min(52, weeksThatFit))
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    if (containerRef.current) observer.observe(containerRef.current)
+    return () => observer.disconnect()
+  }, [step])
+
+  // Slice to the most recent N weeks
+  const visibleWeeks = data.weeks.slice(-maxWeeks)
+  const flatDays = visibleWeeks.flatMap((w) => w.days)
 
   // Pad the first week so Sunday starts at row 0
   const firstDayOfWeek = new Date(flatDays[0]?.date + 'T00:00:00').getDay()
@@ -57,11 +81,7 @@ export const CommitGrid = ({ data }: Props) => {
     columns.push(paddedDays.slice(i, i + 7))
   }
 
-  const monthLabels = getMonthLabels(data.weeks)
-  const cellSize = 12
-  const gap = 3
-  const step = cellSize + gap
-  const labelWidth = 32
+  const monthLabels = getMonthLabels(visibleWeeks)
 
   const handleMouseEnter = (
     day: { date: string; count: number },
@@ -77,8 +97,8 @@ export const CommitGrid = ({ data }: Props) => {
   }
 
   return (
-    <div className="relative">
-      <div className="overflow-x-auto pb-2">
+    <div ref={containerRef} className="relative">
+      <div className="pb-2">
         {/* Month labels */}
         <div className="flex" style={{ paddingLeft: labelWidth }}>
           {monthLabels.map(({ label, colIndex }) => (
@@ -179,8 +199,6 @@ export const CommitGrid = ({ data }: Props) => {
         </div>
       )}
 
-      {/* Right fade for mobile scroll hint */}
-      <div className="pointer-events-none absolute right-0 top-0 h-full w-8 bg-gradient-to-l from-[#171717] to-transparent sm:hidden" />
     </div>
   )
 }

--- a/src/components/homepageDev/MainScreenDev.tsx
+++ b/src/components/homepageDev/MainScreenDev.tsx
@@ -7,7 +7,7 @@ import { StatsDev } from './StatsDev'
 
 export const MainScreenDev = () => {
   return (
-    <div className="container mx-auto max-w-4xl bg-inherit p-4 pt-8">
+    <div className="container mx-auto max-w-4xl bg-inherit px-6 pb-4 pt-8 sm:px-4">
       {/* Header */}
       <div className="flex justify-between" id="header">
         <div>
@@ -20,7 +20,7 @@ export const MainScreenDev = () => {
       {/* About ME */}
       <div id="about" className="pt-12">
         <p className="pb-8 font-hand text-4xl text-[#EA9A4F]">About Me</p>
-        <p className="w-3/4  font-geistmono text-[#D0D0D0] opacity-70">
+        <p className="px-4 font-geistmono text-[#D0D0D0] opacity-70 sm:w-3/4">
           a self taught software engineer with a background in quantum physics
           and ML. I specialize in unique solutions to unique problems. Also, a
           CS masters in progress!


### PR DESCRIPTION
## Summary
- Changed DevPage from w-screen to w-full to prevent horizontal overflow on mobile
- Bumped mobile padding to px-6 (px-4 on sm+ screens) for better breathing room
- About Me body text now full width on mobile, 75% on sm+
- About Me body aligned with Experience/Project items via px-4
- Commit grid is now responsive: measures container width and shows only the most recent weeks that fit

## Test plan
- [ ] Open on mobile viewport (375px) — no horizontal scrollbar, proper padding
- [ ] About Me text aligns visually with Experience item content
- [ ] Commit grid shows fewer weeks on mobile, full 52 weeks on desktop
- [ ] Zoom out on desktop — no whitespace on the right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)